### PR TITLE
Fix issue 79: Select content type

### DIFF
--- a/sas/SASEnvironment/Files/localization/resources_de.xml
+++ b/sas/SASEnvironment/Files/localization/resources_de.xml
@@ -243,6 +243,10 @@
   <string key="sasnavigatorInformationMapRelationalType">Information map (relational)</string>
   <string key="sasnavigatorInformationMapOlapType">Information map (OLAP)</string>
   <string key="sasnavigatorPathCheckbox">Setze den Anfangsordner auf den aktuell ausgewählten Ordner:</string>
+  <string key="sasnavigatorTypeCheckbox">Wählen Sie aus, welche Inhaltstypen angezeigt werden sollen:</string>
+  <string key="sasnavigatorInformationMapCheckbox">SAS Information Map</string>  
+  <string key="sasnavigatorSTPCheckbox">SAS Stored Process</string>  
+  <string key="sasnavigatorReportCheckbox">SAS Report</string>
 
   <string key="portletEditNavigatorFolder">Ordner:</string>
   <string key="portletEditNavigatorFolderRequired">FEHLER: Das Ordnerfeld ist erforderlich.</string>

--- a/sas/SASEnvironment/Files/localization/resources_en.xml
+++ b/sas/SASEnvironment/Files/localization/resources_en.xml
@@ -243,6 +243,10 @@
   <string key="sasnavigatorInformationMapRelationalType">Information map (relational)</string>
   <string key="sasnavigatorInformationMapOlapType">Information map (OLAP)</string>
   <string key="sasnavigatorPathCheckbox">Set the initial folder to the current selected folder:</string>
+  <string key="sasnavigatorTypeCheckbox">Select which content types to show:</string>
+  <string key="sasnavigatorInformationMapCheckbox">SAS Information Map</string>  
+  <string key="sasnavigatorSTPCheckbox">SAS Stored Process</string>  
+  <string key="sasnavigatorReportCheckbox">SAS Report</string>
 
   <string key="portletEditNavigatorFolder">Folder:</string>
   <string key="portletEditNavigatorFolderRequired">ERROR: Folder field is required.</string>

--- a/sas/SASEnvironment/Files/localization/resources_ja.xml
+++ b/sas/SASEnvironment/Files/localization/resources_ja.xml
@@ -244,6 +244,10 @@
   <string key="sasnavigatorInformationMapRelationalType">情報マップ（リレーショナル）</string>
   <string key="sasnavigatorInformationMapOlapType">情報マップ (OLAP)</string>
   <string key="sasnavigatorPathCheckbox">初期フォルダを現在選択されているフォルダに設定します:</string>
+  <string key="sasnavigatorTypeCheckbox">表示するコンテンツの種類を選択してください:</string>
+  <string key="sasnavigatorInformationMapCheckbox">SAS Information Map</string>  
+  <string key="sasnavigatorSTPCheckbox">SAS Stored Process</string>  
+  <string key="sasnavigatorReportCheckbox">SAS Report</string>
 
   <string key="portletEditNavigatorFolder">フォルダ：</string>
   <string key="portletEditNavigatorFolderRequired">エラー: フォルダー フィールドは必須です。</string>

--- a/sas/SASEnvironment/Files/portlet/create.psportlet.xslt
+++ b/sas/SASEnvironment/Files/portlet/create.psportlet.xslt
@@ -80,6 +80,9 @@
          <xsl:variable name="newPSId"><xsl:value-of select="substring-after($reposId,'.')"/>.$newPS</xsl:variable>
          <PropertySet Name="PORTLET_CONFIG_ROOT">
             <xsl:attribute name="Id"><xsl:value-of select="$newPSId"/></xsl:attribute>
+            <PropertySets>
+                <PropertySet Name="SMART_OBJECT_TYPE" Desc="" PropertySetName=""/>
+            </PropertySets>
          </PropertySet>
 
          <!-- The portlets that come from the JSR 168 efforts have an additional PropertySet PortletRenderState.

--- a/sas/SASEnvironment/Files/portlet/edit.sasnavigator.xslt
+++ b/sas/SASEnvironment/Files/portlet/edit.sasnavigator.xslt
@@ -26,6 +26,11 @@
 <xsl:variable name="portletEditNavigatorFolderRequired" select="$localeXml/string[@key='portletEditNavigatorFolderRequired']/text()"/>
 <xsl:variable name="sasnavigatorPathCheckbox" select="$localeXml/string[@key='sasnavigatorPathCheckbox']/text()"/>
 
+<xsl:variable name="sasnavigatorTypeCheckbox" select="$localeXml/string[@key='sasnavigatorTypeCheckbox']/text()"/>
+<xsl:variable name="sasnavigatorInformationMapCheckbox" select="$localeXml/string[@key='sasnavigatorInformationMapCheckbox']/text()"/>
+<xsl:variable name="sasnavigatorSTPCheckbox" select="$localeXml/string[@key='sasnavigatorSTPCheckbox']/text()"/>
+<xsl:variable name="sasnavigatorReportCheckbox" select="$localeXml/string[@key='sasnavigatorReportCheckbox']/text()"/>
+
 <!-- Re-usable scripts -->
 
 <xsl:include href="SASPortalApp/sas/SASEnvironment/Files/portlet/form.functions.xslt"/>
@@ -54,6 +59,17 @@
 <!--  The Folder path we store has the prefix SBIP://METASERVER on it.  No need to force the user to enter that, just have them enter the full path -->
 
 <xsl:variable name="portletURIFolder" select="$configPropertySets/PropertySet[@Name='selectedFolder']/SetProperties/Property[@Name='PreferenceInstanceProperty']/@DefaultValue"/>
+<xsl:variable name="portletPIProperty" select="$configPropertySets/PropertySet[@Name='SMART_OBJECT_TYPE']/SetProperties/Property[@Name='PreferenceInstanceProperty']"/>
+<xsl:variable name="portletNavType">
+    <xsl:for-each select="$portletPIProperty">
+        <xsl:value-of select="@DefaultValue" />:<xsl:value-of select="@Id" />,
+        <!--xsl:if test="position() != last()">,</xsl:if-->
+    </xsl:for-each>
+</xsl:variable>
+
+
+
+
 <xsl:variable name="portletPathFolderTemp" select="substring-before(substring-after($portletURIFolder,'SBIP://METASERVER'),'(Folder)')"/>
 <xsl:variable name="portletPathFolder">
    <xsl:choose>
@@ -108,10 +124,100 @@
               <input type="checkbox" id="checkboxPath" name="checkboxPath"></input>
               <label for="checkboxPath"><xsl:value-of select="$sasnavigatorPathCheckbox"/></label>
               <label for="checkboxPath" id="labelPath"></label>
-            
-        </td>
-        <td>&#160;</td>
+            </td>
+            <td>&#160;</td>
+
         </tr>
+        <tr>
+          <td>&#160;</td>
+        </tr>
+        <tr> 
+            <td>&#160;</td>
+            <td>
+              <label for="checkboxPath"><xsl:value-of select="$sasnavigatorTypeCheckbox"/></label>
+            </td>
+         </tr>
+
+        <tr> 
+            <td>&#160;</td>
+            <td>
+              <xsl:variable name="afterInformationMap" select="substring-after($portletNavType, 'InformationMap:')" />
+              <xsl:variable name="valueIM" select="substring-before($afterInformationMap, ',')" />   
+              <input type="checkbox" id="checkboxIM" name="checkboxIM">
+              <xsl:choose>
+                  <!-- Checkbox aktivieren -->
+                  <xsl:when test="contains($portletNavType, 'InformationMap')">
+                      <xsl:attribute name="checked">checked</xsl:attribute>                    
+                      <xsl:attribute name="value"><xsl:value-of select="$valueIM" /></xsl:attribute>
+                  </xsl:when>
+                  <xsl:otherwise/>
+              </xsl:choose>
+              </input>
+               <input type="hidden" name="hiddenIM">
+               <xsl:choose>
+                  <xsl:when test="contains($portletNavType, 'InformationMap')">                 
+                      <xsl:attribute name="value"><xsl:value-of select="$valueIM" /></xsl:attribute>
+                  </xsl:when>
+              </xsl:choose>
+               </input>
+              <label for="checkboxIM"  id="labelIM"><xsl:value-of select="$sasnavigatorInformationMapCheckbox"/></label>
+              <!--label for="checkboxIM" id="labelIM"></label-->
+            </td>
+         </tr>
+
+        <tr> 
+            <td>&#160;</td>
+            <td>
+              <xsl:variable name="afterStoredProcess" select="substring-after($portletNavType, 'StoredProcess:')" />
+              <xsl:variable name="valueSTP" select="substring-before($afterStoredProcess, ',')" />   
+              <input type="checkbox" id="checkboxSTP" name="checkboxSTP">
+              <xsl:choose>
+                  <!-- Checkbox aktivieren -->
+                  <xsl:when test="contains($portletNavType, 'StoredProcess')">
+                      <xsl:attribute name="checked">checked</xsl:attribute>
+                      <xsl:attribute name="value"><xsl:value-of select="$valueSTP" /></xsl:attribute>
+                  </xsl:when>
+                  <xsl:otherwise/>
+              </xsl:choose>
+              </input>
+              <input type="hidden" name="hiddenSTP">
+               <xsl:choose>
+                  <xsl:when test="contains($portletNavType, 'StoredProcess')">                 
+                      <xsl:attribute name="value"><xsl:value-of select="$valueSTP" /></xsl:attribute>
+                  </xsl:when>
+              </xsl:choose>
+               </input>
+              <label for="checkboxSTP" id="labelSTP"><xsl:value-of select="$sasnavigatorSTPCheckbox"/></label>
+              <!--label for="checkboxSTP" id="labelSTP"></label>-->
+            </td>
+         </tr>
+         
+        <tr> 
+            <td>&#160;</td>
+            <td>
+              <xsl:variable name="afterReport" select="substring-after($portletNavType, 'Report:')" />
+              <xsl:variable name="valueR" select="substring-before($afterReport, ',')" />   
+              <input type="checkbox" id="checkboxReport" name="checkboxReport">
+              <xsl:choose>
+                  <!-- Checkbox aktivieren -->
+                  <xsl:when test="contains($portletNavType, 'Report')">
+                      <xsl:attribute name="checked">checked</xsl:attribute>
+                      <xsl:attribute name="value"><xsl:value-of select="$valueR" /></xsl:attribute>
+                  </xsl:when>
+                  <xsl:otherwise/>
+              </xsl:choose>
+              </input>
+              <input type="hidden" name="hiddenReport">
+               <xsl:choose>
+                  <xsl:when test="contains($portletNavType, 'Report')">                 
+                      <xsl:attribute name="value"><xsl:value-of select="$valueR" /></xsl:attribute>
+                  </xsl:when>
+              </xsl:choose>
+               </input>
+              <label for="checkboxReport" id="labelReport"><xsl:value-of select="$sasnavigatorReportCheckbox"/></label>
+              <!--label for="checkboxReport" id="labelReport"></label-->
+            </td>
+         </tr>
          <tr>
           <td nowrap="">
           </td>
@@ -173,8 +279,10 @@
           }
 
         if (validateForm()) {
-        
-           return submitDisableAllForms(); 
+        const context = window.location.pathname.substring(0, window.location.pathname.indexOf("/",1));
+
+         location.href=context;
+          /*return submitDisableAllForms(); */
            } 
 
         else  return false;

--- a/sas/SASEnvironment/Files/portlet/update.sasnavigator.xslt
+++ b/sas/SASEnvironment/Files/portlet/update.sasnavigator.xslt
@@ -26,6 +26,18 @@
 <xsl:variable name="oldFolderURIPropertySet" select="$configPropertySets/PropertySet[@Name='selectedFolder']"/>
 <xsl:variable name="oldFolderURIProperty" select="$oldFolderURIPropertySet/SetProperties/Property[@Name='PreferenceInstanceProperty']"/>
 
+<xsl:variable name="smartObjectPropertySet" select="$configPropertySets/PropertySet[@Name='SMART_OBJECT_TYPE']"/>
+<xsl:variable name="smartObjectPropertySetId" select="$smartObjectPropertySet/@Id"/>
+<!--xsl:variable name="smartObjectPropertySetId">A56YJHUZ.AB0001I5</xsl:variable-->
+
+<xsl:variable name="reposId" select="Mod_Request/NewMetadata/Metareposid"/>
+<xsl:variable name="imSelected" select="Mod_Request/NewMetadata/IM_SELECTED"/>
+<xsl:variable name="imID" select="Mod_Request/NewMetadata/IM_ID"/>
+<xsl:variable name="stpSelected" select="Mod_Request/NewMetadata/STP_SELECTED"/>
+<xsl:variable name="stpID" select="Mod_Request/NewMetadata/STP_ID"/>
+<xsl:variable name="reportSelected" select="Mod_Request/NewMetadata/REPORT_SELECTED"/>
+<xsl:variable name="reportID" select="Mod_Request/NewMetadata/REPORT_ID"/>
+
 <xsl:variable name="oldFolderURI" select="$oldFolderURIProperty/@DefaultValue"/>
 <xsl:variable name="oldFolderPath" select="substring-before(substring-after($oldFolderURI,$folderURIPrefix),$folderURISuffix)"/>
 
@@ -59,6 +71,108 @@
 
   <xsl:when test="not($oldFolderURI = $newFolderURI) or $commonPropertiesChanged">
     <Multiple_Requests>
+
+    <!--  Add new Information Map Property -->
+    <xsl:if test="$imSelected='on' and string($imID) = ''">
+         <AddMetadata>
+            <Metadata>
+               <Property Name="PreferenceInstanceProperty" SQLType="12" DefaultValue="InformationMap">
+                  <AssociatedPropertySet>
+                     <PropertySet Name="SMART_OBJECT_TYPE">
+                        <xsl:attribute name="ObjRef"><xsl:value-of select="$smartObjectPropertySetId"/></xsl:attribute>
+                     </PropertySet>
+                  </AssociatedPropertySet>
+               </Property>
+            </Metadata>
+            <Reposid><xsl:value-of select="$reposId"/></Reposid>
+            <NS>SAS</NS>
+            <Flags>268435456</Flags>
+            <Options/>
+         </AddMetadata>
+    </xsl:if>
+
+      <!--  Delete Information Map Property -->
+      <xsl:if test="$imSelected='off' and string($imID) != '' and ($reportSelected='on' or $stpSelected='on')">
+         <DeleteMetadata>
+            <Metadata>
+               <Property Name="PreferenceInstanceProperty">
+                  <xsl:attribute name="Id"><xsl:value-of select="$imID"/></xsl:attribute>
+               </Property>
+            </Metadata>
+            <Reposid><xsl:value-of select="$reposId"/></Reposid>
+            <NS>SAS</NS>
+            <Flags>268435456</Flags>
+            <Options/>
+         </DeleteMetadata>
+      </xsl:if>
+
+      <!--  Add new Stored Process Property -->
+      <xsl:if test="$stpSelected='on' and string($stpID) = ''">
+            <AddMetadata>
+               <Metadata>
+                  <Property Name="PreferenceInstanceProperty" SQLType="12" DefaultValue="StoredProcess">
+                     <AssociatedPropertySet>
+                        <PropertySet Name="SMART_OBJECT_TYPE">
+                           <xsl:attribute name="ObjRef"><xsl:value-of select="$smartObjectPropertySetId"/></xsl:attribute>
+                        </PropertySet>
+                     </AssociatedPropertySet>
+                  </Property>
+               </Metadata>
+               <Reposid><xsl:value-of select="$reposId"/></Reposid>
+               <NS>SAS</NS>
+               <Flags>268435456</Flags>
+               <Options/>
+            </AddMetadata>
+      </xsl:if>
+
+      <!--  Delete Stored Process Property -->
+      <xsl:if test="$stpSelected='off' and string($stpID) != '' and ($reportSelected='on' or $imSelected='on')">
+         <DeleteMetadata>
+            <Metadata>
+               <Property Name="PreferenceInstanceProperty">
+                  <xsl:attribute name="Id"><xsl:value-of select="$stpID"/></xsl:attribute>
+               </Property>
+            </Metadata>
+            <Reposid><xsl:value-of select="$reposId"/></Reposid>
+            <NS>SAS</NS>
+            <Flags>268435456</Flags>
+            <Options/>
+         </DeleteMetadata>
+      </xsl:if>
+
+      <!--  Add new Report Property -->
+      <xsl:if test="$reportSelected='on' and string($reportID) = ''">
+            <AddMetadata>
+               <Metadata>
+                  <Property Name="PreferenceInstanceProperty" SQLType="12" DefaultValue="Report">
+                     <AssociatedPropertySet>
+                        <PropertySet Name="SMART_OBJECT_TYPE">
+                           <xsl:attribute name="ObjRef"><xsl:value-of select="$smartObjectPropertySetId"/></xsl:attribute>
+                        </PropertySet>
+                     </AssociatedPropertySet>
+                  </Property>
+               </Metadata>
+               <Reposid><xsl:value-of select="$reposId"/></Reposid>
+               <NS>SAS</NS>
+               <Flags>268435456</Flags>
+               <Options/>
+            </AddMetadata>
+      </xsl:if>
+
+         <!--  Delete Stored Process Property -->
+      <xsl:if test="$reportSelected='off' and string($reportID) != '' and ($stpSelected='on' or $imSelected='on')">
+         <DeleteMetadata>
+            <Metadata>
+               <Property Name="PreferenceInstanceProperty">
+                  <xsl:attribute name="Id"><xsl:value-of select="$reportID"/></xsl:attribute>
+               </Property>
+            </Metadata>
+            <Reposid><xsl:value-of select="$reposId"/></Reposid>
+            <NS>SAS</NS>
+            <Flags>268435456</Flags>
+            <Options/>
+         </DeleteMetadata>
+      </xsl:if>
 
     <UpdateMetadata>
 

--- a/sas/SASEnvironment/SASCode/Steps/portlet/update.sasnavigator.parameters.sas
+++ b/sas/SASEnvironment/SASCode/Steps/portlet/update.sasnavigator.parameters.sas
@@ -3,3 +3,43 @@
      put "<Path>&Path.</Path>";
      %end;
 
+
+  %if (%symexist(checkboxIM)) %then %do;     
+     put "<IM_SELECTED>&checkboxIM.</IM_SELECTED>";
+     %end;
+     %else %do;
+         put "<IM_SELECTED>off</IM_SELECTED>";
+     %end;
+
+
+   %if (%symexist(hiddenIM)) %then %do;     
+     put "<IM_ID>&hiddenIM.</IM_ID>";
+     %end;
+
+  %if (%symexist(checkboxSTP)) %then %do;     
+     put "<STP_SELECTED>&checkboxSTP.</STP_SELECTED>";
+     %end;
+     %else %do;
+         put "<STP_SELECTED>off</STP_SELECTED>";
+     %end;
+
+
+  %if (%symexist(hiddenSTP)) %then %do;     
+     put "<STP_ID>&hiddenSTP.</STP_ID>";
+     %end;
+
+
+  %if (%symexist(checkboxReport)) %then %do;     
+     put "<REPORT_SELECTED>&checkboxReport.</REPORT_SELECTED>";
+     %end;
+     %else %do;
+         put "<REPORT_SELECTED>off</REPORT_SELECTED>";
+     %end;
+
+  %if (%symexist(hiddenReport)) %then %do;     
+     put "<REPORT_ID>&hiddenReport.</REPORT_ID>";
+     %end;
+
+
+
+


### PR DESCRIPTION
Hi, this change allows users to select content types on the 'Edit Content' page in SASNavigator portlet. This PR implements issue #79.

<img width="633" height="295" alt="image" src="https://github.com/user-attachments/assets/3c4dbc1b-d747-4a3d-8288-345549105fe5" />
